### PR TITLE
feat(zeebe): add `modelerTemplateIcon` property

### DIFF
--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -346,6 +346,24 @@
           "type": "Integer"
         }
       ]
+    },
+    {
+      "name": "ModelerTemplateIcon",
+      "superClass": [
+        "Element"
+      ],
+      "meta": {
+        "allowedIn": [
+          "zeebe:TemplateSupported"
+        ]
+      },
+      "properties": [
+        {
+          "name": "body",
+          "type": "String",
+          "isBody": true
+        }
+      ]
     }
   ]
 }

--- a/test/fixtures/xml/task-modelerTemplateIcon.part.bpmn
+++ b/test/fixtures/xml/task-modelerTemplateIcon.part.bpmn
@@ -1,0 +1,8 @@
+<Task xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+          xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+          zeebe:modelerTemplate="foo"
+          zeebe:modelerTemplateVersion="1">
+  <extensionElements>
+    <zeebe:modelerTemplateIcon>data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3C/svg%3E</zeebe:modelerTemplateIcon>
+  </extensionElements>
+</Task>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -595,6 +595,38 @@ describe('read', function() {
 
       });
 
+
+      describe('zeebe:modelerTemplateIcon', function() {
+
+        it('on Task', async function() {
+
+          // given
+          const xml = readFile('test/fixtures/xml/task-modelerTemplateIcon.part.bpmn');
+
+          // when
+          const {
+            rootElement: task
+          } = await moddle.fromXML(xml, 'bpmn:Task');
+
+          // then
+          expect(task).to.jsonEqual({
+            $type: 'bpmn:Task',
+            modelerTemplate: 'foo',
+            modelerTemplateVersion: 1,
+            extensionElements: {
+              $type: 'bpmn:ExtensionElements',
+              values: [
+                {
+                  $type: 'zeebe:ModelerTemplateIcon',
+                  body: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3C/svg%3E",
+                }
+              ]
+            }
+          });
+        });
+
+      });
+
     });
 
   });

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -264,6 +264,26 @@ describe('write', function() {
       expect(xml).to.eql(expectedXML);
     });
 
+
+    it('zeebe:modelerTemplateIcon', async function() {
+
+      // given
+      const moddleElement = moddle.create('zeebe:ModelerTemplateIcon', {
+        body: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3C/svg%3E",
+      });
+
+      const expectedXML = '<zeebe:modelerTemplateIcon ' +
+        'xmlns:zeebe="http://camunda.org/schema/zeebe/1.0">' +
+          "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3C/svg%3E" +
+        '</zeebe:modelerTemplateIcon>';
+
+      // when
+      const xml = await write(moddleElement);
+
+      // then
+      expect(xml).to.eql(expectedXML);
+    });
+
   });
 
 });


### PR DESCRIPTION
Closes #23

Example

```xml
<bpmn:serviceTask id="Activity_08bosyf" zeebe:modelerTemplate="icon.template.sendgrid18">
  <bpmn:extensionElements>
    <zeebe:modelerTemplateIcon>data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.14264 5.69666H5.72264V10.2767H1.14264V5.69666V5.69666Z' fill='white'/%3E%3Cpath d='M1.14264 5.69666H5.72264V10.2767H1.14264V5.69666V5.69666Z' fill='%2399E1F4'/%3E%3Cpath d='M5.72333 10.2767H10.2767V14.83H5.72333V10.2767V10.2767Z' fill='white'/%3E%3Cpath d='M5.72333 10.2767H10.2767V14.83H5.72333V10.2767V10.2767Z' fill='%2399E1F4'/%3E%3Cpath d='M1.14264 14.8307H5.72264V14.8573H1.14264V14.8307V14.8307ZM1.14264 10.2773H5.72264V14.8307H1.14264V10.2773V10.2773Z' fill='%231A82E2'/%3E%3Cpath d='M5.72333 1.14267H10.2767V5.696H5.72333V1.14267V1.14267ZM10.2767 5.72267H14.8567V10.276H10.2767V5.72267V5.72267Z' fill='%2300B3E3'/%3E%3Cpath d='M5.72333 10.2767H10.2767V5.69666H5.72333V10.2767Z' fill='%23009DD9'/%3E%3Cpath d='M10.2767 1.14267H14.8567V5.696H10.2767V1.14267V1.14267ZM10.2767 5.69667H14.8567V5.72334H10.2767V5.69667Z' fill='%231A82E2'/%3E%3C/svg%3E</zeebe:modelerTemplateIcon>
  </bpmn:extensionElements>
</bpmn:serviceTask>
```