### PR TITLE
fix(extension): allow copy extensions to user task

### DIFF
--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -52,7 +52,8 @@
           "bpmn:Event",
           "bpmn:ReceiveTask",
           "zeebe:ZeebeServiceTask",
-          "bpmn:SubProcess"
+          "bpmn:SubProcess",
+          "bpmn:UserTask"
         ]
       }
     },
@@ -93,7 +94,8 @@
         "allowedIn": [
           "bpmn:CallActivity",
           "zeebe:ZeebeServiceTask",
-          "bpmn:SubProcess"
+          "bpmn:SubProcess",
+          "bpmn:UserTask"
         ]
       }
     },
@@ -108,7 +110,8 @@
           "bpmn:Event",
           "bpmn:ReceiveTask",
           "zeebe:ZeebeServiceTask",
-          "bpmn:SubProcess"
+          "bpmn:SubProcess",
+          "bpmn:UserTask"
         ]
       }
     },
@@ -119,7 +122,8 @@
       ],
       "meta": {
         "allowedIn": [
-          "zeebe:ZeebeServiceTask"
+          "zeebe:ZeebeServiceTask",
+          "bpmn:UserTask"
         ]
       },
       "properties": [

--- a/test/spec/extension.js
+++ b/test/spec/extension.js
@@ -188,6 +188,25 @@ describe('extension - can copy', function() {
     });
 
 
+    it('should allow on UserTask', function() {
+
+      // given
+      var ioMapping = moddle.create('zeebe:IoMapping'),
+          input = moddle.create('zeebe:Input'),
+          userTask = moddle.create('bpmn:UserTask'),
+          extensionElements = moddle.create('bpmn:ExtensionElements');
+
+      ioMapping.$parent = extensionElements;
+      extensionElements.$parent = userTask;
+
+      // when
+      var canCopyProperty = zeebeModdleExtension.canCopyProperty(input, extensionElements);
+
+      // then
+      expect(canCopyProperty).not.to.be.false;
+    });
+
+
     it('should not allow on ReceiveTask', function() {
 
       // given
@@ -326,6 +345,25 @@ describe('extension - can copy', function() {
     });
 
 
+    it('should allow on UserTask', function() {
+
+      // given
+      var ioMapping = moddle.create('zeebe:IoMapping'),
+          output = moddle.create('zeebe:Output'),
+          userTask = moddle.create('bpmn:UserTask'),
+          extensionElements = moddle.create('bpmn:ExtensionElements');
+
+      ioMapping.$parent = extensionElements;
+      extensionElements.$parent = userTask;
+
+      // when
+      var canCopyProperty = zeebeModdleExtension.canCopyProperty(output, extensionElements);
+
+      // then
+      expect(canCopyProperty).not.to.be.false;
+    });
+
+
     it('should not allow on Task', function() {
 
       // given
@@ -344,6 +382,7 @@ describe('extension - can copy', function() {
       expect(canCopyProperty).to.be.false;
     });
 
+
     it('should allow on NoneEndEvents', function() {
 
       // given
@@ -361,6 +400,7 @@ describe('extension - can copy', function() {
       // then
       expect(canCopyProperty).to.not.be.false;
     });
+
 
     it('should allow on MessageEndEvents', function() {
 
@@ -413,6 +453,23 @@ describe('extension - can copy', function() {
           extensionElements = moddle.create('bpmn:ExtensionElements');
 
       extensionElements.$parent = receiveTask;
+
+      // when
+      var canCopyProperty = zeebeModdleExtension.canCopyProperty(ioMapping, extensionElements);
+
+      // then
+      expect(canCopyProperty).not.to.be.false;
+    });
+
+
+    it('should allow on UserTask', function() {
+
+      // given
+      var ioMapping = moddle.create('zeebe:IoMapping'),
+          userTask = moddle.create('bpmn:UserTask'),
+          extensionElements = moddle.create('bpmn:ExtensionElements');
+
+      extensionElements.$parent = userTask;
 
       // when
       var canCopyProperty = zeebeModdleExtension.canCopyProperty(ioMapping, extensionElements);
@@ -553,6 +610,23 @@ describe('extension - can copy', function() {
           extensionElements = moddle.create('bpmn:ExtensionElements');
 
       extensionElements.$parent = businessRuleTask;
+
+      // when
+      var canCopyProperty = zeebeModdleExtension.canCopyProperty(taskHeaders, extensionElements);
+
+      // then
+      expect(canCopyProperty).not.to.be.false;
+    });
+
+
+    it('should allow on UserTask', function() {
+
+      // given
+      var taskHeaders = moddle.create('zeebe:TaskHeaders'),
+          userTask = moddle.create('bpmn:UserTask'),
+          extensionElements = moddle.create('bpmn:ExtensionElements');
+
+      extensionElements.$parent = userTask;
 
       // when
       var canCopyProperty = zeebeModdleExtension.canCopyProperty(taskHeaders, extensionElements);


### PR DESCRIPTION
Related to https://github.com/bpmn-io/bpmn-js-properties-panel/issues/738

> npx @bpmn-io/sr camunda/camunda-bpmn-js -l camunda-cloud/zeebe-bpmn-moddle#738-lost-task-headers -c "npm run start:cloud"