### PR TITLE
Support `zeebe:properties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [zeebe-bpmn-moddle](https://github.com/zeebe-io/zeebe-bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+## 0.13.0
+
+* `FEAT`: support `zeebe:properties` ([#30](https://github.com/camunda-cloud/zeebe-bpmn-moddle/issues/30))
+
 ## 0.12.2
 
 * `FIX`: allow copy extensions to user task ([#28](https://github.com/camunda-cloud/zeebe-bpmn-moddle/pull/28))

--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -331,6 +331,51 @@
       ]
     },
     {
+      "name": "Properties",
+      "superClass": [
+        "Element"
+      ],
+      "properties": [
+        {
+          "name": "properties",
+          "type": "Property",
+          "isMany": true
+        }
+      ],
+      "meta": {
+        "allowedIn": [
+          "zeebe:PropertiesHolder"
+        ]
+      }
+    },
+    {
+      "name": "Property",
+      "properties": [
+        {
+          "name": "name",
+          "type": "String",
+          "isAttr": true
+        },
+        {
+          "name": "value",
+          "type": "String",
+          "isAttr": true
+        }
+      ],
+      "meta": {
+        "allowedIn": [
+          "zeebe:PropertiesHolder"
+        ]
+      }
+    },
+    {
+      "name": "PropertiesHolder",
+      "isAbstract": true,
+      "extends": [
+        "bpmn:FlowNode"
+      ]
+    },
+    {
       "name": "TemplateSupported",
       "isAbstract": true,
       "extends": [

--- a/test/fixtures/xml/startEvent-zeebe-properties.part.bpmn
+++ b/test/fixtures/xml/startEvent-zeebe-properties.part.bpmn
@@ -1,0 +1,8 @@
+<bpmn:startEvent xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="start">
+  <bpmn:extensionElements>
+    <zeebe:properties>
+      <zeebe:property name="id" value="start" />
+      <zeebe:property name="type" value="event" />
+    </zeebe:properties>
+  </bpmn:extensionElements>
+</bpmn:startEvent>

--- a/test/fixtures/xml/zeebe-properties.bpmn
+++ b/test/fixtures/xml/zeebe-properties.bpmn
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0qh9wc7" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="ZeebePropertiesTest" name="Zeebe Properties Test" isExecutable="true">
+    <bpmn:startEvent id="start" name="Start">
+      <bpmn:extensionElements>
+        <zeebe:properties>
+          <zeebe:property name="id" value="start" />
+          <zeebe:property name="type" value="event" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_1ghqtxk</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:exclusiveGateway id="fork" default="Flow_0829k0f">
+      <bpmn:extensionElements>
+        <zeebe:properties>
+          <zeebe:property name="id" value="fork" />
+          <zeebe:property name="type" value="gateway" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1ghqtxk</bpmn:incoming>
+      <bpmn:outgoing>Flow_0829k0f</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1yxvdzm</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1ghqtxk" sourceRef="start" targetRef="fork" />
+    <bpmn:sequenceFlow id="Flow_0829k0f" sourceRef="fork" targetRef="task" />
+    <bpmn:exclusiveGateway id="join">
+      <bpmn:incoming>Flow_1mj7vtb</bpmn:incoming>
+      <bpmn:incoming>Flow_1e9zid1</bpmn:incoming>
+      <bpmn:outgoing>Flow_0zeynk4</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1mj7vtb" sourceRef="task" targetRef="join" />
+    <bpmn:endEvent id="end" name="End">
+      <bpmn:incoming>Flow_0zeynk4</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0zeynk4" sourceRef="join" targetRef="end" />
+    <bpmn:sequenceFlow id="Flow_1yxvdzm" sourceRef="fork" targetRef="timer">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">= day of week(today()) = "Tuesday"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1e9zid1" sourceRef="timer" targetRef="join" />
+    <bpmn:serviceTask id="task" name="Task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="task" />
+        <zeebe:properties>
+          <zeebe:property name="id" value="task" />
+          <zeebe:property name="type" value="task" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0829k0f</bpmn:incoming>
+      <bpmn:outgoing>Flow_1mj7vtb</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:intermediateCatchEvent id="timer" name="Timer">
+      <bpmn:incoming>Flow_1yxvdzm</bpmn:incoming>
+      <bpmn:outgoing>Flow_1e9zid1</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_17m8b78">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT15S</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="ZeebePropertiesTest">
+      <bpmndi:BPMNEdge id="Flow_1ghqtxk_di" bpmnElement="Flow_1ghqtxk">
+        <di:waypoint x="208" y="120" />
+        <di:waypoint x="265" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0829k0f_di" bpmnElement="Flow_0829k0f">
+        <di:waypoint x="315" y="120" />
+        <di:waypoint x="380" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mj7vtb_di" bpmnElement="Flow_1mj7vtb">
+        <di:waypoint x="480" y="120" />
+        <di:waypoint x="545" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0zeynk4_di" bpmnElement="Flow_0zeynk4">
+        <di:waypoint x="595" y="120" />
+        <di:waypoint x="662" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yxvdzm_di" bpmnElement="Flow_1yxvdzm">
+        <di:waypoint x="290" y="145" />
+        <di:waypoint x="290" y="230" />
+        <di:waypoint x="412" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1e9zid1_di" bpmnElement="Flow_1e9zid1">
+        <di:waypoint x="448" y="230" />
+        <di:waypoint x="570" y="230" />
+        <di:waypoint x="570" y="145" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0g93o5e_di" bpmnElement="start">
+        <dc:Bounds x="172" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="179" y="145" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0x3gaj1_di" bpmnElement="fork" isMarkerVisible="true">
+        <dc:Bounds x="265" y="95" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="282" y="155" width="17" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_01u8vik_di" bpmnElement="join" isMarkerVisible="true">
+        <dc:Bounds x="545" y="95" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1iiq4dg_di" bpmnElement="end">
+        <dc:Bounds x="662" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="670" y="145" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0nj48w2_di" bpmnElement="task">
+        <dc:Bounds x="380" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_11lmofq_di" bpmnElement="timer">
+        <dc:Bounds x="412" y="212" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="416" y="255" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -113,38 +113,6 @@ describe('read', function() {
     });
 
 
-    describe('zeebe:Subscription', function() {
-
-      it('on Message', async function() {
-
-        // given
-        var xml = readFile('test/fixtures/xml/message-zeebe-subscription.part.bpmn');
-
-        // when
-        const {
-          rootElement: proc
-        } = await moddle.fromXML(xml, 'bpmn:Message');
-
-        // then
-        expect(proc).to.jsonEqual({
-          $type: 'bpmn:Message',
-          id: 'Message',
-          name: 'Money collected',
-          extensionElements: {
-            $type: 'bpmn:ExtensionElements',
-            values: [
-              {
-                $type: 'zeebe:Subscription',
-                correlationKey: 'orderId'
-              }
-            ]
-          }
-        });
-      });
-
-    });
-
-
     describe('zeebe:calledElement', function() {
 
       it('on CallActivity', async function() {

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -81,6 +81,48 @@ describe('read', function() {
     });
 
 
+    describe('zeebe:Properties', function() {
+
+      it('on StartEvent', async function() {
+
+        // given
+        var xml = readFile('test/fixtures/xml/startEvent-zeebe-properties.part.bpmn');
+
+        // when
+        const {
+          rootElement: event
+        } = await moddle.fromXML(xml, 'bpmn:StartEvent');
+
+        // then
+        expect(event).to.jsonEqual({
+          $type: 'bpmn:StartEvent',
+          id: 'start',
+          extensionElements: {
+            $type: 'bpmn:ExtensionElements',
+            values: [
+              {
+                $type: 'zeebe:Properties',
+                properties: [
+                  {
+                    $type: 'zeebe:Property',
+                    name: 'id',
+                    value: 'start'
+                  },
+                  {
+                    $type: 'zeebe:Property',
+                    name: 'type',
+                    value: 'event'
+                  }
+                ]
+              }
+            ]
+          }
+        });
+      });
+
+    });
+
+
     describe('zeebe:Subscription', function() {
 
       it('on Message', async function() {

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -18,18 +18,26 @@ describe('import -> export roundtrip', function() {
 
     return async function() {
 
+      // given
       var xml = readFile(file);
 
       var moddle = createModdle();
 
+      // when
       const {
-        rootElement: definitions
+        rootElement: definitions,
+        warnings
       } = await moddle.fromXML(xml, 'bpmn:Definitions');
 
+      // then
+      expect(warnings).to.be.empty;
+
+      // but when
       const {
         xml: savedXML
       } = await moddle.toXML(definitions);
 
+      // then
       expect(stripSpaces(savedXML)).to.eql(stripSpaces(xml));
     };
   }

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -41,4 +41,7 @@ describe('import -> export roundtrip', function() {
 
   });
 
+
+  it('should keep zeebe:properties', validateExport('test/fixtures/xml/zeebe-properties.bpmn'));
+
 });


### PR DESCRIPTION
Provides support for the newly added [`zeebe:properties` extension point](https://github.com/camunda/zeebe/issues/9868).

----

Closes #30 